### PR TITLE
Use testnet client in dapp

### DIFF
--- a/dapps/react-dapp-v2/.env.local.example
+++ b/dapps/react-dapp-v2/.env.local.example
@@ -1,7 +1,8 @@
 NEXT_PUBLIC_PROJECT_ID=39bc...
 NEXT_PUBLIC_RELAY_URL=wss://relay.walletconnect.com
 NEXT_PUBLIC_HEDERA_ACCOUNT_ID=
-# WARNING: Do not use this approach of storing/accessing private keys in production.
+# !!!WARNING!!!
+# Do not use this approach of storing/accessing private keys in production.
 # This app is not configured with a secure storage mechanism, so this is just the
 # best way to make it work and showcase Hedera integration with WalletConnect.
 NEXT_PUBLIC_HEDERA_PRIVATE_KEY=

--- a/dapps/react-dapp-v2/.env.local.example
+++ b/dapps/react-dapp-v2/.env.local.example
@@ -1,2 +1,7 @@
 NEXT_PUBLIC_PROJECT_ID=39bc...
 NEXT_PUBLIC_RELAY_URL=wss://relay.walletconnect.com
+NEXT_PUBLIC_HEDERA_ACCOUNT_ID=
+# WARNING: Do not use this approach of storing/accessing private keys in production.
+# This app is not configured with a secure storage mechanism, so this is just the
+# best way to make it work and showcase Hedera integration with WalletConnect.
+NEXT_PUBLIC_HEDERA_PRIVATE_KEY=

--- a/dapps/react-dapp-v2/README.md
+++ b/dapps/react-dapp-v2/README.md
@@ -21,6 +21,8 @@ Install the app's dependencies:
 yarn
 ```
 
+If you want to test Hedera integration, go to [Hedera Portal](https://portal.hedera.com/) to create a Testnet account.
+
 Set up your local environment variables by copying the example into your own `.env.local` file:
 
 ```bash
@@ -31,6 +33,8 @@ Your `.env.local` now contains the following environment variables:
 
 - `NEXT_PUBLIC_PROJECT_ID` (placeholder) - You can generate your own ProjectId at https://cloud.walletconnect.com
 - `NEXT_PUBLIC_RELAY_URL` (already set)
+- `NEXT_PUBLIC_HEDERA_ACCOUNT_ID` (placeholder, optional) - Get your testnet account id from https://portal.hedera.com/
+- `NEXT_PUBLIC_HEDERA_PRIVATE_KEY` (placeholder, optional) - Get your testnet private key from https://portal.hedera.com/
 
 ## Develop
 

--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -28,13 +28,16 @@ import {
 } from "@kadena/client";
 import { PactNumber } from "@kadena/pactjs";
 import {
-  Hbar,
-  TransferTransaction,
+  AccountCreateTransaction,
   AccountId,
-  TransactionId,
+  Hbar,
+  PrivateKey,
   RequestType,
+  TopicCreateTransaction,
   TopicMessageSubmitTransaction,
   Transaction,
+  TransactionId,
+  TransferTransaction,
 } from "@hashgraph/sdk";
 import {
   KadenaAccount,
@@ -47,6 +50,7 @@ import {
   verifySignature,
   HederaParamsFactory,
   HederaSessionRequestParams,
+  hederaTestnetClient,
 } from "../helpers";
 import { useWalletConnectClient } from "./ClientContext";
 import {
@@ -1504,11 +1508,28 @@ export function JsonRpcContextProvider({
 
   // -------- HEDERA RPC METHODS --------
 
-  const _buildTestTransferTransaction = (address: string) => {
+  const _buildTestTransferTransaction = async (address: string) => {
     const payerAccountId = new AccountId(Number(address.split(".").pop()));
     const transactionId = TransactionId.generate(payerAccountId);
     const transactionAmt = 1000;
-    const receiverAddress = "0.0.432284"; // hard-coded to my 2nd test account for now
+    let receiverAddress = "0.0.54321"; // Transferring to this account may fail, but we attempt to create a new one below
+
+    if (hederaTestnetClient) {
+      //Create new account keys
+      const newAccountPrivateKeys = PrivateKey.generateED25519();
+      const newAccountPublicKey = newAccountPrivateKeys.publicKey;
+
+      //Create a new account with 1,000 tinybar starting balance
+      const newAccount = await new AccountCreateTransaction()
+        .setKey(newAccountPublicKey)
+        .setInitialBalance(Hbar.fromTinybars(1000))
+        .execute(hederaTestnetClient);
+
+      //Get the new account ID
+      const receipt = await newAccount.getReceipt(hederaTestnetClient);
+      receiverAddress = receipt.accountId?.toString() ?? receiverAddress;
+    }
+
     const memo = `Transfer amount: ${Hbar.fromTinybars(
       transactionAmt
     ).toString()}, from: ${address}, to: ${receiverAddress}`;
@@ -1529,7 +1550,7 @@ export function JsonRpcContextProvider({
         const method =
           DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_EXECUTE_TRANSACTION;
 
-        const transaction = _buildTestTransferTransaction(address);
+        const transaction = await _buildTestTransferTransaction(address);
 
         const params = HederaParamsFactory.buildTransactionPayload(
           RequestType.CryptoTransfer,
@@ -1565,9 +1586,17 @@ export function JsonRpcContextProvider({
 
         const payerAccountId = new AccountId(Number(address.split(".").pop()));
         const transactionId = TransactionId.generate(payerAccountId);
+        let topicId = "0.0.12345"; // Submitting to this topic will fail, but we attempt to create a new one below
+
+        if (hederaTestnetClient) {
+          const topicCreateTxn = new TopicCreateTransaction();
+          const response = await topicCreateTxn.execute(hederaTestnetClient);
+          const receipt = await response.getReceipt(hederaTestnetClient);
+          topicId = receipt.topicId?.toString() ?? topicId;
+        }
 
         const transaction = new TopicMessageSubmitTransaction()
-          .setTopicId("0.0.432078") // Topic created for testing this app
+          .setTopicId(topicId)
           .setMessage(
             `Hello from hedera-walletconnect-dapp at ${new Date().toISOString()}`
           )
@@ -1605,7 +1634,7 @@ export function JsonRpcContextProvider({
         const method =
           DEFAULT_HEDERA_METHODS.HEDERA_SIGN_AND_RETURN_TRANSACTION;
 
-        const transaction = _buildTestTransferTransaction(address);
+        const transaction = await _buildTestTransferTransaction(address);
 
         const params = HederaParamsFactory.buildTransactionPayload(
           RequestType.CryptoTransfer,

--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -51,6 +51,7 @@ import {
   HederaSessionRequestParams,
   hederaTestnetClient,
   createOrRestoreHederaTopicId,
+  createOrRestoreHederaTransferReceiverAddress,
 } from "../helpers";
 import { useWalletConnectClient } from "./ClientContext";
 import {
@@ -1512,23 +1513,8 @@ export function JsonRpcContextProvider({
     const payerAccountId = new AccountId(Number(address.split(".").pop()));
     const transactionId = TransactionId.generate(payerAccountId);
     const transactionAmt = 1000;
-    let receiverAddress = "0.0.54321"; // Transferring to this account may fail, but we attempt to create a new one below
-
-    if (hederaTestnetClient) {
-      //Create new account keys
-      const newAccountPrivateKeys = PrivateKey.generateED25519();
-      const newAccountPublicKey = newAccountPrivateKeys.publicKey;
-
-      //Create a new account with 1,000 tinybar starting balance
-      const newAccount = await new AccountCreateTransaction()
-        .setKey(newAccountPublicKey)
-        .setInitialBalance(Hbar.fromTinybars(1000))
-        .execute(hederaTestnetClient);
-
-      //Get the new account ID
-      const receipt = await newAccount.getReceipt(hederaTestnetClient);
-      receiverAddress = receipt.accountId?.toString() ?? receiverAddress;
-    }
+    const receiverAddress =
+      await createOrRestoreHederaTransferReceiverAddress();
 
     const memo = `Transfer amount: ${Hbar.fromTinybars(
       transactionAmt

--- a/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
+++ b/dapps/react-dapp-v2/src/contexts/JsonRpcContext.tsx
@@ -33,7 +33,6 @@ import {
   Hbar,
   PrivateKey,
   RequestType,
-  TopicCreateTransaction,
   TopicMessageSubmitTransaction,
   Transaction,
   TransactionId,
@@ -51,6 +50,7 @@ import {
   HederaParamsFactory,
   HederaSessionRequestParams,
   hederaTestnetClient,
+  createOrRestoreHederaTopicId,
 } from "../helpers";
 import { useWalletConnectClient } from "./ClientContext";
 import {
@@ -1586,14 +1586,7 @@ export function JsonRpcContextProvider({
 
         const payerAccountId = new AccountId(Number(address.split(".").pop()));
         const transactionId = TransactionId.generate(payerAccountId);
-        let topicId = "0.0.12345"; // Submitting to this topic will fail, but we attempt to create a new one below
-
-        if (hederaTestnetClient) {
-          const topicCreateTxn = new TopicCreateTransaction();
-          const response = await topicCreateTxn.execute(hederaTestnetClient);
-          const receipt = await response.getReceipt(hederaTestnetClient);
-          topicId = receipt.topicId?.toString() ?? topicId;
-        }
+        const topicId = await createOrRestoreHederaTopicId();
 
         const transaction = new TopicMessageSubmitTransaction()
           .setTopicId(topicId)

--- a/dapps/react-dapp-v2/src/helpers/hedera.ts
+++ b/dapps/react-dapp-v2/src/helpers/hedera.ts
@@ -101,7 +101,8 @@ export const apiGetHederaAccountBalance = async (address: string) => {
 const createTestnetClient = () => {
   try {
     /**
-     * WARNING: Do not use this approach of storing/accessing private keys in production.
+     * !!!WARNING!!!
+     * Do not use this approach of storing/accessing private keys in production.
      * This app is not configured with a secure storage mechanism, so this is just the
      * best way to make it work and showcase Hedera integration with WalletConnect.
      */

--- a/dapps/react-dapp-v2/src/helpers/hedera.ts
+++ b/dapps/react-dapp-v2/src/helpers/hedera.ts
@@ -1,6 +1,12 @@
 import axios, { AxiosInstance } from "axios";
 import { EngineTypes } from "@walletconnect/types";
-import { AccountId, Hbar, RequestType, Transaction } from "@hashgraph/sdk";
+import {
+  AccountId,
+  Client,
+  Hbar,
+  RequestType,
+  Transaction,
+} from "@hashgraph/sdk";
 
 type TypedRequestParams<T> = Omit<EngineTypes.RequestParams, "request"> & {
   request: Omit<EngineTypes.RequestParams["request"], "params"> & {
@@ -91,3 +97,36 @@ export const apiGetHederaAccountBalance = async (address: string) => {
     symbol: "ℏ",
   };
 };
+
+const createTestnetClient = () => {
+  try {
+    /**
+     * WARNING: Do not use this approach of storing/accessing private keys in production.
+     * This app is not configured with a secure storage mechanism, so this is just the
+     * best way to make it work and showcase Hedera integration with WalletConnect.
+     */
+    const privateKey = process.env.NEXT_PUBLIC_HEDERA_PRIVATE_KEY;
+    const accountAddress = process.env.NEXT_PUBLIC_HEDERA_ACCOUNT_ID;
+
+    if (!accountAddress || !privateKey) {
+      throw new Error(
+        "Missing required env vars: `NEXT_PUBLIC_HEDERA_ACCOUNT_ID` and/or `HEDERA_PRIVATE_KEY`"
+      );
+    }
+
+    const id = Number(accountAddress.split(".").pop());
+    const accountId = new AccountId(id);
+
+    const client = Client.forTestnet();
+    client.setOperator(accountId, privateKey);
+    client.setDefaultMaxTransactionFee(new Hbar(100));
+    client.setMaxQueryPayment(new Hbar(50));
+
+    return client;
+  } catch (e) {
+    console.error("Failed to initialize Hedera wallet", e);
+    return null;
+  }
+};
+
+export const hederaTestnetClient = createTestnetClient();

--- a/wallets/react-wallet-v2/README.md
+++ b/wallets/react-wallet-v2/README.md
@@ -26,7 +26,9 @@ Example is built atop of [NextJS](https://nextjs.org/) in order to abstract comp
 
 3. Install dependencies `yarn install` or `npm install`
 
-4. Setup your environment variables
+4. Install dependencies `yarn install` or `npm install`
+
+5. Setup your environment variables
 
 ```bash
 cp .env.local.example .env.local
@@ -39,7 +41,7 @@ Your `.env.local` now contains the following environment variables:
 - `NEXT_PUBLIC_HEDERA_ACCOUNT_ID` (placeholder, optional) - Get your testnet account id from https://portal.hedera.com/
 - `NEXT_PUBLIC_HEDERA_PRIVATE_KEY` (placeholder, optional) - Get your testnet private key from https://portal.hedera.com/
 
-5. Run `yarn dev` or `npm run dev` to start local development
+6. Run `yarn dev` or `npm run dev` to start local development
 
 ## Navigating through example
 


### PR DESCRIPTION
### Summary
- Adds env var configuration for Hedera account ID and private key.
- Adds util functions to create a Hedera Testnet client, and create or restore topic ID and transfer recipient account address

Tested manually, and works like a charm!